### PR TITLE
fix: display the correct minute value for the counter

### DIFF
--- a/src/components/Counter.jsx
+++ b/src/components/Counter.jsx
@@ -102,6 +102,6 @@ const toPercentage = (seconds, total) => parseInt(Math.round((seconds / total * 
 const formatValue = (seconds, total) => {
 
   return (seconds > 60 ?
-    (seconds / 60).toFixed(0) + ":" + (seconds % 60).toString().padStart(2, '0') + "m" :
+    Math.floor(seconds / 60).toFixed(0) + ":" + (seconds % 60).toString().padStart(2, '0') + "m" :
     seconds + "s")
 }


### PR DESCRIPTION
Commit 9675ded ([PR #68](https://github.com/KeziahMoselle/tempus/pull/68), [issue #64](https://github.com/KeziahMoselle/tempus/issues/64)) displayed seconds for counter values below 1 minute. However, for values above 1 minute the minute value incorrectly updates on the 30 second time interval instead of the 60 second interval (e.g. 1:28, 1:29, 2:30, 2:31 and 2:58, 2:59, 2:00, 2:01)