### PR TITLE
fix: stop card border showing through title text

### DIFF
--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -594,6 +594,9 @@ select {
   position: absolute;
   top: -13px;
   font-size: 0.7em;
+  background-color: white;
+  padding: 0 2px;
+  margin: 0 -2px;
 }
 
 .card-item {


### PR DESCRIPTION
The title text for each card has the border showing through it. This commit adds a background colour to the title text so the border is "removed".